### PR TITLE
Tests/update matrix modernize example

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 'stable', '^1.22', '^1.21', '^1.20', '^1.19', '~1.18', '~1.17', '~1.16', '~1.15', '~1.14', '~1.13', '~1.12' ]
+        go: [ 
+          'stable', 
+          '^1.24', 
+          '^1.23', 
+          '^1.22', 
+          '^1.21', 
+          '^1.20', 
+          '^1.19', 
+          '~1.18', 
+          '~1.17',
+          '~1.16',
+          '~1.15',
+          '~1.14',
+          '~1.13',
+          '~1.12'
+        ]
     name: Go ${{ matrix.go }} sample
     steps:
       - name: Checkout repo
@@ -23,6 +38,7 @@ jobs:
       - name: Run Race tests
         run: |
           go test --race
+
   coverage:
     runs-on: ubuntu-latest
     steps:
@@ -39,6 +55,6 @@ jobs:
           go test -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage.txt

--- a/examples/stego.go
+++ b/examples/stego.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"image"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -55,7 +54,7 @@ func OpenImageFromPath(filename string) (image.Image, error) {
 
 func main() {
 	if encode {
-		message, err := ioutil.ReadFile(messageInputFile) // Read the message from the message file (alternative to os.Open )
+		message, err := os.ReadFile(messageInputFile) // Read the message from the message file (alternative to os.Open )
 		if err != nil {
 			print("Error reading from file!!!")
 			return
@@ -103,7 +102,7 @@ func main() {
 
 		// if the user specifies a location to write the message to...
 		if messageOutputFile != "" {
-			err := ioutil.WriteFile(messageOutputFile, msg, 0644) // write the message to the given output file
+			err := os.WriteFile(messageOutputFile, msg, 0644) // write the message to the given output file
 
 			if err != nil {
 				fmt.Println("There was an error writing to file: ", messageOutputFile)

--- a/steganography_test.go
+++ b/steganography_test.go
@@ -39,15 +39,19 @@ func TestEncodeFromPngFile(t *testing.T) {
 	if err != nil {
 		log.Printf("Error Encoding file %v", err)
 		t.FailNow()
-
 	}
+
 	outFile, err := os.Create(encodedInputFilePng)
 	if err != nil {
 		log.Printf("Error creating file %s: %v", encodedInputFilePng, err)
 		t.FailNow()
-
 	}
-	w.WriteTo(outFile)
+
+	_, err = w.WriteTo(outFile)
+	if err != nil {
+		log.Printf("Error writing file %s: %v", encodedInputFilePng, err)
+		t.FailNow()
+	}
 	defer outFile.Close()
 }
 
@@ -57,8 +61,8 @@ func TestEncodeFromJpgFile(t *testing.T) {
 	if err != nil {
 		log.Printf("Error opening file %s: %v", rawInputFileJpg, err)
 		t.FailNow()
-
 	}
+
 	defer inFile.Close()
 
 	reader := bufio.NewReader(inFile)
@@ -67,20 +71,25 @@ func TestEncodeFromJpgFile(t *testing.T) {
 		log.Printf("Error decoding. %v", err)
 		t.FailNow()
 	}
+
 	w := new(bytes.Buffer)
 	err = Encode(w, img, bitmessage) // Encode the message into the image file
 	if err != nil {
 		log.Printf("Error Encoding file %v", err)
 		t.FailNow()
-
 	}
+
 	outFile, err := os.Create(encodedInputFileJpg)
 	if err != nil {
 		log.Printf("Error creating file %s: %v", encodedInputFileJpg, err)
 		t.FailNow()
-
 	}
-	w.WriteTo(outFile)
+
+	_, err = w.WriteTo(outFile)
+	if err != nil {
+		log.Printf("Error writing file %s: %v", encodedInputFilePng, err)
+		t.FailNow()
+	}
 	defer outFile.Close()
 }
 


### PR DESCRIPTION
- adds go 1.23 and 1.24 to testing matrix
- check error for WriteTo in test
- remove deprecated ioutil